### PR TITLE
Add alarm margin

### DIFF
--- a/PreciseManeuver.Unity.csproj
+++ b/PreciseManeuver.Unity.csproj
@@ -76,11 +76,11 @@
   <ItemGroup>
     <Reference Include="System" />
     <Reference Include="UnityEngine">
-      <HintPath>..\Libs\UnityEngine.dll</HintPath>
+      <HintPath>..\..\..\..\..\..\Program Files (x86)\Steam\steamapps\common\Kerbal Space Program\KSP_x64_Data\Managed\UnityEngine.dll</HintPath>
     </Reference>
     <Reference Include="UnityEngine.UI, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\Libs\UnityEngine.UI.dll</HintPath>
+      <HintPath>..\..\..\..\..\..\Program Files (x86)\Steam\steamapps\common\Kerbal Space Program\KSP_x64_Data\Managed\UnityEngine.UI.dll</HintPath>
     </Reference>
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />

--- a/PreciseManeuver.csproj
+++ b/PreciseManeuver.csproj
@@ -32,10 +32,10 @@
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="Assembly-CSharp">
-      <HintPath>..\Libs\Assembly-CSharp.dll</HintPath>
+      <HintPath>..\..\..\..\..\..\Program Files (x86)\Steam\steamapps\common\Kerbal Space Program\KSP_x64_Data\Managed\Assembly-CSharp.dll</HintPath>
     </Reference>
     <Reference Include="Assembly-CSharp-firstpass">
-      <HintPath>..\Libs\Assembly-CSharp-firstpass.dll</HintPath>
+      <HintPath>..\..\..\..\..\..\Program Files (x86)\Steam\steamapps\common\Kerbal Space Program\KSP_x64_Data\Managed\Assembly-CSharp-firstpass.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Data" />
@@ -43,11 +43,11 @@
     <Reference Include="System.Xml.Linq" />
     <Reference Include="System.Xml" />
     <Reference Include="UnityEngine">
-      <HintPath>..\Libs\UnityEngine.dll</HintPath>
+      <HintPath>..\..\..\..\..\..\Program Files (x86)\Steam\steamapps\common\Kerbal Space Program\KSP_x64_Data\Managed\UnityEngine.dll</HintPath>
     </Reference>
     <Reference Include="UnityEngine.UI, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\Libs\UnityEngine.UI.dll</HintPath>
+      <HintPath>..\..\..\..\..\..\Program Files (x86)\Steam\steamapps\common\Kerbal Space Program\KSP_x64_Data\Managed\UnityEngine.UI.dll</HintPath>
     </Reference>
   </ItemGroup>
   <ItemGroup>

--- a/properties/AssemblyInfo.cs
+++ b/properties/AssemblyInfo.cs
@@ -31,8 +31,8 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("2.4.1")]
-[assembly: AssemblyFileVersion("2.4.1")]
+[assembly: AssemblyVersion("2.4.2")]
+[assembly: AssemblyFileVersion("2.4.2")]
 [assembly: AssemblyInformationalVersion("")]
 
 [assembly: KSPAssembly("PreciseManeuver", 2, 4)]

--- a/src/CompatibilityChecker.cs
+++ b/src/CompatibilityChecker.cs
@@ -61,7 +61,7 @@ namespace KSPPreciseManeuver {
             // Even if you don't lock down functionality, you should return true if your users
             // can expect a future update to be available.
             //
-            return Versioning.version_major == 1 && Versioning.version_minor == 4;
+            return Versioning.version_major == 1 && Versioning.version_minor == 5;
 
             /*-----------------------------------------------*\
             | IMPLEMENTERS SHOULD NOT EDIT BEYOND THIS POINT! |

--- a/src/NodeManager.cs
+++ b/src/NodeManager.cs
@@ -92,6 +92,7 @@ namespace KSPPreciseManeuver {
 
       currentAlarm.VesselID = FlightGlobals.ActiveVessel.id.ToString ();
       currentAlarm.Notes = KSP.Localization.Localizer.Format ("precisemaneuver_KAC_note");
+      currentAlarm.AlarmMargin = 600;
     }
 
     internal void DeleteAlarm () {


### PR DESCRIPTION
Added an alarm margin while the creation of the KSC alarm, so 'Time to Event' will match the 'Time to Node'.
'Time to Alarm' will still be displayed with the same margin as before