### PR TITLE
Update max compatibility to KSP 1.11

### DIFF
--- a/PreciseManeuver.version
+++ b/PreciseManeuver.version
@@ -24,7 +24,7 @@
     },
     "KSP_VERSION_MAX": {
         "MAJOR": 1,
-        "MINOR": 8,
+        "MINOR": 11,
         "PATCH": 99
     }
 }


### PR DESCRIPTION
Hi @radistmorse, users are reporting on the forum thread that this mod works fine on KSP 1.10 and 1.11. If you'd like to make that official, you can merge this pull request to update the compatibility as seen by KSP-AVC and CKAN. Cheers!

https://forum.kerbalspaceprogram.com/index.php?/topic/128303-18x-precise-maneuver-editor/page/18/